### PR TITLE
Cannot use ngx-dropzone-label in ngx-dropzone-video-preview

### DIFF
--- a/projects/ngx-dropzone/src/lib/ngx-dropzone-preview/ngx-dropzone-video-preview/ngx-dropzone-video-preview.component.scss
+++ b/projects/ngx-dropzone/src/lib/ngx-dropzone-preview/ngx-dropzone-video-preview/ngx-dropzone-video-preview.component.scss
@@ -6,6 +6,10 @@
 
 	&:hover,
 	&:focus {
+    video {
+			opacity: 0.7;
+    }
+
 		ngx-dropzone-remove-badge {
 			opacity: 1;
 		}
@@ -18,5 +22,10 @@
 	video {
 		max-height: 100%;
 		border-radius: 5px;
+  }
+
+  ::ng-deep ngx-dropzone-label {
+		position: absolute;
+		overflow-wrap: break-word;
 	}
 }

--- a/projects/ngx-dropzone/src/lib/ngx-dropzone-preview/ngx-dropzone-video-preview/ngx-dropzone-video-preview.component.ts
+++ b/projects/ngx-dropzone/src/lib/ngx-dropzone-preview/ngx-dropzone-video-preview/ngx-dropzone-video-preview.component.ts
@@ -8,6 +8,7 @@ import { DomSanitizer, SafeUrl } from '@angular/platform-browser';
     <video *ngIf="sanitizedVideoSrc" controls (click)="$event.stopPropagation()">
       <source [src]="sanitizedVideoSrc" />
     </video>
+    <ng-content select="ngx-dropzone-label"></ng-content>
     <ngx-dropzone-remove-badge *ngIf="removable" (click)="_remove($event)">
     </ngx-dropzone-remove-badge>
 	`,


### PR DESCRIPTION
Hi,

I notice **ngx-dropzone-video-preview** component template doesn't have `ng-content` with selector `'ngx-dropzone-label'`, so it cannot show label.
I added it as you can see in the commit.

Thank you.