### PR TITLE
feat(a11y): propagate `id` attribute to native element

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ This component has the following Input properties:
 * `[maxFileSize]`: Set the maximum size a single file may have. Defaults to `undefined`.
 * `[disabled]`: Disable any user interaction with the component. Defaults to `false`.
 * `[expandable]`: Allow the dropzone container to expand vertically as the number of previewed files increases. Defaults to `false` which means that it will allow for horizontal scrolling.
+* `[id]`: Set the id attribute of the native input element. Defaults to `undefined`.
 
 It has the following Output event:
 

--- a/projects/ngx-dropzone/src/lib/ngx-dropzone/ngx-dropzone.component.html
+++ b/projects/ngx-dropzone/src/lib/ngx-dropzone/ngx-dropzone.component.html
@@ -1,4 +1,4 @@
-<input #fileInput type="file" style="display: none;" [multiple]="multiple" [accept]="accept"
+<input #fileInput [id]="id" type="file" style="display: none;" [multiple]="multiple" [accept]="accept"
   (change)="_onFilesSelected($event)">
 <ng-content select="ngx-dropzone-label" *ngIf="!_hasPreviews"></ng-content>
 <ng-content select="ngx-dropzone-preview"></ng-content>

--- a/projects/ngx-dropzone/src/lib/ngx-dropzone/ngx-dropzone.component.ts
+++ b/projects/ngx-dropzone/src/lib/ngx-dropzone/ngx-dropzone.component.ts
@@ -38,6 +38,9 @@ export class NgxDropzoneComponent {
   /** Set the accepted file types. Defaults to '*'. */
   @Input() accept = '*';
 
+  /** Set the id attribute on the native input element */
+  @Input() id: string;
+
   /** Disable any user interaction with the component. */
   @Input()
   @HostBinding('class.ngx-dz-disabled')


### PR DESCRIPTION
Propagate `id` attribute passed to `ngx-dropzone` to the native `input`
element in order to allow users to add e.g. labels.

Addresses issue #44.

I'm kind of limited (behind proxies etc.) so i wasn't able to `npm install` and test, so if someone could just verify this it'd be great.