### PR TITLE
feat(a11y): make dropzone focusable

### DIFF
--- a/projects/ngx-dropzone/src/lib/ngx-dropzone/ngx-dropzone.component.html
+++ b/projects/ngx-dropzone/src/lib/ngx-dropzone/ngx-dropzone.component.html
@@ -1,4 +1,4 @@
-<input #fileInput type="file" style="display: none;" [multiple]="multiple" [accept]="accept"
+<input #fileInput type="file" [multiple]="multiple" [accept]="accept"
   (change)="_onFilesSelected($event)">
 <ng-content select="ngx-dropzone-label" *ngIf="!_hasPreviews"></ng-content>
 <ng-content select="ngx-dropzone-preview"></ng-content>

--- a/projects/ngx-dropzone/src/lib/ngx-dropzone/ngx-dropzone.component.scss
+++ b/projects/ngx-dropzone/src/lib/ngx-dropzone/ngx-dropzone.component.scss
@@ -12,6 +12,22 @@ $dz-border: #717386;
 	border-radius: 5px;
 	font-size: 16px;
 
+  /* Make the input invisible, but still visible to screen readers & targetable with keyboard */
+  & input {
+    width: 0.1px;
+    height: 0.1px;
+    opacity: 0;
+    overflow: hidden;
+    position: absolute;
+    z-index: -1;
+
+    &:focus + ngx-dropzone-label {
+      outline: -webkit-focus-ring-color auto 5px; 
+      /* Fallback for older browsers */
+      outline: 1px dotted #000;
+    }
+  }
+
 	&.ngx-dz-hovered {
 		border-style: solid;
 	}


### PR DESCRIPTION
Addressing issue #46 

I've just dry-coded this so it will most likely not work right off the bat, but the idea should be the same. Setting `display: none;` makes the input inaccessible with a keyboard, so we have to use some "hacks" to work around it. Now i outline the `ngx-dropzone-label` when the "hidden" input is focused.