### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ It will add the classes `ngx-dz-hovered` and `ngx-dz-disabled` to its host eleme
 This component has the following Input properties:
 
 * `[multiple]`: Allow the selection of multiple files at once. Defaults to `true`.
-* `[accept]`: Set the accepted file types (as for a native file element). Defaults to `'*'`.
+* `accept`: Set the accepted file types (as for a native file element). Defaults to `'*'`. Example: `accept="image/jpeg,image/jpg,image/png,image/gif"`
 * `[maxFileSize]`: Set the maximum size a single file may have, in *bytes*. Defaults to `undefined`.
 * `[disabled]`: Disable any user interaction with the component. Defaults to `false`.
 * `[expandable]`: Allow the dropzone container to expand vertically as the number of previewed files increases. Defaults to `false` which means that it will allow for horizontal scrolling.


### PR DESCRIPTION
After some tests with some guys about the issue (https://github.com/peterfreeman/ngx-dropzone/issues/63) we think that the correct way to use is, at least from version 2.2.2 is use `accept`instead of `[accept]`. I've changed this line in doc and added an example. 

Thanks for the work :)