### PR TITLE
Added the ability to preload files

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,21 +38,26 @@ export class AppModule { }
 <ngx-dropzone (change)="onSelect($event)">
 	<ngx-dropzone-label>Drop it, baby!</ngx-dropzone-label>
 	<ngx-dropzone-preview *ngFor="let f of files" [removable]="true" (removed)="onRemove(f)">
-		<ngx-dropzone-label>{{ f.name }} ({{ f.type }})</ngx-dropzone-label>
+		<ngx-dropzone-label>{{ f.file.name  }} ({{ f.file.type }})</ngx-dropzone-label>
 	</ngx-dropzone-preview>
 </ngx-dropzone>
 ```
 
 ```js
 // in app.component.ts
-files: File[] = [];
+files: DropZoneFileModel[] = [];
 
-onSelect(event) {
+onFilesAdded(event: any) {
   console.log(event);
-  this.files.push(...event.addedFiles);
+  event.addedFiles.forEach((element: any) => {
+    this.files.push({
+      file: element,
+      isMock: false
+    })
+  });
 }
 
-onRemove(event) {
+onRemove(event: DropZoneFileModel) {
   console.log(event);
   this.files.splice(this.files.indexOf(event), 1);
 }
@@ -62,15 +67,45 @@ You can also use special preview components to preview images or videos:
 
 ```html
 <ngx-dropzone-image-preview ngProjectAs="ngx-dropzone-preview" *ngFor="let f of files" [file]="f">
-  <ngx-dropzone-label>{{ f.name }} ({{ f.type }})</ngx-dropzone-label>
+  <ngx-dropzone-label>{{ f.file.name  }} ({{ f.file.type }})</ngx-dropzone-label>
 </ngx-dropzone-image-preview>
 ```
 
 ```html
 <ngx-dropzone-video-preview ngProjectAs="ngx-dropzone-preview" *ngFor="let f of files" [file]="f">
-  <ngx-dropzone-label>{{ f.name }} ({{ f.type }})</ngx-dropzone-label>
+  <ngx-dropzone-label>{{ f.file.name  }} ({{ f.file.type }})</ngx-dropzone-label>
 </ngx-dropzone-video-preview>
 ```
+
+
+
+* prelaod files into the drop-zone
+* if you have for example a set of urls that you want to add them befor drop-zone is loaded ,you can use this method
+```js
+  files: DropZoneFileModel[] = [];
+  ngAfterViewInit() {
+    const url = 'https://fakeimg.pl/440x230/282828/32eddd/?retina=1&text=ngx-dropzone-mock-img';
+    const nameWithType = url.split('/')[url.split('/').length - 1];
+    const name = nameWithType.split('.')[0];
+    const type = nameWithType.split('.')[1] ? nameWithType.split('.')[1].toLowerCase() : 'png';
+    var mockFile: File = {
+      name: name,
+      type: "image/" + type,
+      size: 1024,
+      arrayBuffer: null,
+      lastModified: null,
+      slice: null,
+      stream: null,
+      text: null,
+    };
+    this.files.push({
+      isMock: true,
+      file: mockFile,
+      fileSrc: url
+    })
+  }
+```
+
 
 ## Component documentation
 
@@ -80,7 +115,7 @@ This component is the actual dropzone container. It contains the label and any f
 It has an event listener for file drops and you can also click it to open the native file explorer for selection.
 
 Use it as a stand-alone component `<ngx-dropzone></ngx-dropzone>` or by adding it as an attribute to a custom `div` (`<div class="custom-dropzone" ngx-dropzone></div>`).
-It will add the classes `ngx-dz-hovered` and `ngx-dz-disabled` to its host element if necessary. You could override the styling of these effects if you like to.
+It will add the classes `ngx-dz-hovered` and `ngx-dz-disabled` to it's host element if necessary. You could override the styling of these effects if you like to.
 
 This component has the following Input properties:
 
@@ -96,7 +131,7 @@ It has the following Output event:
 
 * `(change)`: Emitted when any files were added or rejected. It returns a `NgxDropzoneChangeEvent` with the properties `source: NgxDropzoneComponent`, `addedFiles: File[]` and `rejectedFiles: RejectedFile[]`.
 
-The `RejectedFile` extends the native File and adds an optional reason property to tell you why the file was rejected. Its value will be either `'type'` for the wrong acceptance type, `size` if it exceeds the maximum file size or `no_multiple` if multiple is set to false and more than one file is provided.
+The `RejectedFile` extends the native File and adds an optional reason property to tell you why the file was rejected. it's value will be either `'type'` for the wrong acceptance type, `size` if it exceeds the maximum file size or `no_multiple` if multiple is set to false and more than one file is provided.
 
 If you'd like to show the native file selector programmatically then do it as follows:
 
@@ -116,7 +151,12 @@ This component shows a basic file preview when added inside the dropzone contain
 
 This component has the following Input properties:
 
-* `[file]`: The dropped file to preview.
+* `[file]`: the "file" type is DropZoneFileModel which contains :
+   * `isMock`: if you need preload to file into drop-zone set this to true .
+   * `file`: The dropped file to preview , if you need to preload file into drop-zone creat a mock file and pass it .
+   * `fileSrc`: which is a string and if you need to preload file into drop-zone set it with the url that you have  .
+   * `fileId`: it's useful when you want to keep track of the files, whether it's peloaded or user selected  .
+
 * `[removable]`: Allow the user to remove files. Required to allow keyboard interaction and show the remove badge on hover.
 
 It has the following Output event:

--- a/projects/ngx-dropzone/src/lib/_data/dropzone-file.model.ts
+++ b/projects/ngx-dropzone/src/lib/_data/dropzone-file.model.ts
@@ -1,0 +1,6 @@
+export interface DropZoneFileModel {
+  isMock: boolean,
+  file: File,
+  fileSrc?: string,
+  fileId?: string
+}

--- a/projects/ngx-dropzone/src/lib/_data/index.ts
+++ b/projects/ngx-dropzone/src/lib/_data/index.ts
@@ -1,0 +1,1 @@
+export * from './dropzone-file.model';

--- a/projects/ngx-dropzone/src/lib/ngx-dropzone-preview/ngx-dropzone-image-preview/ngx-dropzone-image-preview.component.ts
+++ b/projects/ngx-dropzone/src/lib/ngx-dropzone-preview/ngx-dropzone-image-preview/ngx-dropzone-image-preview.component.ts
@@ -1,6 +1,7 @@
-import { Component, OnInit, HostBinding, Input } from '@angular/core';
+import { Component, AfterViewInit, Input } from '@angular/core';
 import { NgxDropzonePreviewComponent } from '../ngx-dropzone-preview.component';
 import { DomSanitizer, SafeStyle } from '@angular/platform-browser';
+import { DropZoneFileModel } from '../../_data';
 
 @Component({
   selector: 'ngx-dropzone-image-preview',
@@ -18,7 +19,7 @@ import { DomSanitizer, SafeStyle } from '@angular/platform-browser';
     }
   ]
 })
-export class NgxDropzoneImagePreviewComponent extends NgxDropzonePreviewComponent implements OnInit {
+export class NgxDropzoneImagePreviewComponent extends NgxDropzonePreviewComponent implements AfterViewInit {
 
   constructor(
     sanitizer: DomSanitizer
@@ -28,23 +29,29 @@ export class NgxDropzoneImagePreviewComponent extends NgxDropzonePreviewComponen
 
   /** The file to preview. */
   @Input()
-  set file(value: File) {
+  set file(value: DropZoneFileModel) {
     this._file = value;
     this.renderImage();
   }
-  get file(): File { return this._file; }
+  get file(): DropZoneFileModel { return this._file; }
 
   /** The image data source. */
   defaultImgLoading = 'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiBzdHlsZT0ibWFyZ2luOiBhdXRvOyBiYWNrZ3JvdW5kOiByZ2IoMjQxLCAyNDIsIDI0Mykgbm9uZSByZXBlYXQgc2Nyb2xsIDAlIDAlOyBkaXNwbGF5OiBibG9jazsgc2hhcGUtcmVuZGVyaW5nOiBhdXRvOyIgd2lkdGg9IjIyNHB4IiBoZWlnaHQ9IjIyNHB4IiB2aWV3Qm94PSIwIDAgMTAwIDEwMCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ieE1pZFlNaWQiPgo8Y2lyY2xlIGN4PSI1MCIgY3k9IjUwIiByPSIxNCIgc3Ryb2tlLXdpZHRoPSIzIiBzdHJva2U9IiM4NWEyYjYiIHN0cm9rZS1kYXNoYXJyYXk9IjIxLjk5MTE0ODU3NTEyODU1MiAyMS45OTExNDg1NzUxMjg1NTIiIGZpbGw9Im5vbmUiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCI+CiAgPGFuaW1hdGVUcmFuc2Zvcm0gYXR0cmlidXRlTmFtZT0idHJhbnNmb3JtIiB0eXBlPSJyb3RhdGUiIGR1cj0iMS4xNjI3OTA2OTc2NzQ0MTg0cyIgcmVwZWF0Q291bnQ9ImluZGVmaW5pdGUiIGtleVRpbWVzPSIwOzEiIHZhbHVlcz0iMCA1MCA1MDszNjAgNTAgNTAiPjwvYW5pbWF0ZVRyYW5zZm9ybT4KPC9jaXJjbGU+CjxjaXJjbGUgY3g9IjUwIiBjeT0iNTAiIHI9IjEwIiBzdHJva2Utd2lkdGg9IjMiIHN0cm9rZT0iI2JiY2VkZCIgc3Ryb2tlLWRhc2hhcnJheT0iMTUuNzA3OTYzMjY3OTQ4OTY2IDE1LjcwNzk2MzI2Nzk0ODk2NiIgc3Ryb2tlLWRhc2hvZmZzZXQ9IjE1LjcwNzk2MzI2Nzk0ODk2NiIgZmlsbD0ibm9uZSIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIj4KICA8YW5pbWF0ZVRyYW5zZm9ybSBhdHRyaWJ1dGVOYW1lPSJ0cmFuc2Zvcm0iIHR5cGU9InJvdGF0ZSIgZHVyPSIxLjE2Mjc5MDY5NzY3NDQxODRzIiByZXBlYXRDb3VudD0iaW5kZWZpbml0ZSIga2V5VGltZXM9IjA7MSIgdmFsdWVzPSIwIDUwIDUwOy0zNjAgNTAgNTAiPjwvYW5pbWF0ZVRyYW5zZm9ybT4KPC9jaXJjbGU+CjwhLS0gW2xkaW9dIGdlbmVyYXRlZCBieSBodHRwczovL2xvYWRpbmcuaW8vIC0tPjwvc3ZnPg==';
   imageSrc: any = this.sanitizer.bypassSecurityTrustUrl(this.defaultImgLoading);
 
-  ngOnInit() {
+  ngAfterViewInit() {
     this.renderImage();
   }
 
   private renderImage() {
-    this.readFile()
-      .then(img => setTimeout(() => this.imageSrc = img))
-      .catch(err => console.error(err));
+    if (this.file.isMock) {
+      this.imageSrc = this.file.fileSrc
+    } else {
+      this.readFile()
+        .then(img => this.imageSrc = img)
+        .catch(err => console.error(err));
+    }
+
   }
+
 }

--- a/projects/ngx-dropzone/src/lib/ngx-dropzone-preview/ngx-dropzone-preview.component.ts
+++ b/projects/ngx-dropzone/src/lib/ngx-dropzone-preview/ngx-dropzone-preview.component.ts
@@ -1,63 +1,64 @@
 import { Component, Input, Output, EventEmitter, HostBinding, HostListener } from '@angular/core';
 import { coerceBooleanProperty } from '../helpers';
 import { SafeStyle, DomSanitizer } from '@angular/platform-browser';
+import { DropZoneFileModel } from '../_data';
 
 enum KEY_CODE {
-	BACKSPACE = 8,
-	DELETE = 46
+  BACKSPACE = 8,
+  DELETE = 46
 }
 
 @Component({
-	selector: 'ngx-dropzone-preview',
-	template: `
+  selector: 'ngx-dropzone-preview',
+  template: `
 		<ng-content select="ngx-dropzone-label"></ng-content>
 		<ngx-dropzone-remove-badge *ngIf="removable" (click)="_remove($event)">
 		</ngx-dropzone-remove-badge>
 	`,
-	styleUrls: ['./ngx-dropzone-preview.component.scss']
+  styleUrls: ['./ngx-dropzone-preview.component.scss']
 })
 export class NgxDropzonePreviewComponent {
 
-	constructor(
-		protected sanitizer: DomSanitizer
-	) { }
+  constructor(
+    protected sanitizer: DomSanitizer
+  ) { }
 
-	protected _file: File;
+  protected _file: DropZoneFileModel;
 
-	/** The file to preview. */
-	@Input()
-	set file(value: File) { this._file = value; }
-	get file(): File { return this._file; }
+  /** The file to preview. */
+  @Input()
+  set file(value: DropZoneFileModel) { this._file = value; }
+  get file(): DropZoneFileModel { return this._file; }
 
-	/** Allow the user to remove files. */
-	@Input()
-	get removable(): boolean {
-		return this._removable;
-	}
-	set removable(value: boolean) {
-		this._removable = coerceBooleanProperty(value);
-	}
-	protected _removable = false;
+  /** Allow the user to remove files. */
+  @Input()
+  get removable(): boolean {
+    return this._removable;
+  }
+  set removable(value: boolean) {
+    this._removable = coerceBooleanProperty(value);
+  }
+  protected _removable = false;
 
-	/** Emitted when the element should be removed. */
-	@Output() readonly removed = new EventEmitter<File>();
+  /** Emitted when the element should be removed. */
+  @Output() readonly removed = new EventEmitter<DropZoneFileModel>();
 
-	@HostListener('keyup', ['$event'])
-	keyEvent(event: KeyboardEvent) {
-		switch (event.keyCode) {
-			case KEY_CODE.BACKSPACE:
-			case KEY_CODE.DELETE:
-				this.remove();
-				break;
-			default:
-				break;
-		}
-	}
+  @HostListener('keyup', ['$event'])
+  keyEvent(event: KeyboardEvent) {
+    switch (event.keyCode) {
+      case KEY_CODE.BACKSPACE:
+      case KEY_CODE.DELETE:
+        this.remove();
+        break;
+      default:
+        break;
+    }
+  }
 
-	/** We use the HostBinding to pass these common styles to child components. */
-	@HostBinding('style')
-	get hostStyle(): SafeStyle {
-		const styles = `
+  /** We use the HostBinding to pass these common styles to child components. */
+  @HostBinding('style')
+  get hostStyle(): SafeStyle {
+    const styles = `
 			display: flex;
 			height: 140px;
 			min-height: 140px;
@@ -71,43 +72,47 @@ export class NgxDropzonePreviewComponent {
 			position: relative;
 		`;
 
-		return this.sanitizer.bypassSecurityTrustStyle(styles);
-	}
+    return this.sanitizer.bypassSecurityTrustStyle(styles);
+  }
 
-	/** Make the preview item focusable using the tab key. */
-	@HostBinding('tabindex') tabIndex = 0;
+  /** Make the preview item focusable using the tab key. */
+  @HostBinding('tabindex') tabIndex = 0;
 
-	/** Remove method to be used from the template. */
-	_remove(event) {
-		event.stopPropagation();
-		this.remove();
-	}
+  /** Remove method to be used from the template. */
+  _remove(event) {
+    event.stopPropagation();
+    this.remove();
+  }
 
-	/** Remove the preview item (use from component code). */
-	remove() {
-		if (this._removable) {
-			this.removed.next(this.file);
-		}
-	}
+  /** Remove the preview item (use from component code). */
+  remove() {
+    if (this._removable) {
+      this.removed.next(this.file);
+    }
+  }
 
-	protected async readFile(): Promise<string | ArrayBuffer> {
-		return new Promise<string | ArrayBuffer>((resolve, reject) => {
-			const reader = new FileReader();
+  protected async readFile(): Promise<string | ArrayBuffer> {
+    if (this.file.isMock) {
+      return this.file.fileSrc
+    } else {
+      return new Promise<string | ArrayBuffer>((resolve, reject) => {
+        const reader = new FileReader();
 
-			reader.onload = e => {
-				resolve((e.target as FileReader).result);
-			};
+        reader.onload = e => {
+          resolve((e.target as FileReader).result);
+        };
 
-			reader.onerror = e => {
-				console.error(`FileReader failed on file ${this.file.name}.`);
-				reject(e);
-			};
+        reader.onerror = e => {
+          console.error(`FileReader failed on file ${this.file.file.name}.`);
+          reject(e);
+        };
 
-			if (!this.file) {
-				return reject('No file to read. Please provide a file using the [file] Input property.');
-			}
+        if (!this.file) {
+          return reject('No file to read. Please provide a file using the [file] Input property.');
+        }
 
-			reader.readAsDataURL(this.file);
-		});
-	}
+        reader.readAsDataURL(this.file.file);
+      });
+    }
+  }
 }

--- a/projects/ngx-dropzone/src/lib/ngx-dropzone-preview/ngx-dropzone-video-preview/ngx-dropzone-video-preview.component.ts
+++ b/projects/ngx-dropzone/src/lib/ngx-dropzone-preview/ngx-dropzone-video-preview/ngx-dropzone-video-preview.component.ts
@@ -43,8 +43,13 @@ export class NgxDropzoneVideoPreviewComponent extends NgxDropzonePreviewComponen
      * We sanitize the URL here to enable the preview.
      * Please note that this could cause security issues!
      **/
-    this.videoSrc = URL.createObjectURL(this.file);
-    this.sanitizedVideoSrc = this.sanitizer.bypassSecurityTrustUrl(this.videoSrc);
+    if (this.file.isMock) {
+      this.sanitizedVideoSrc = this.file.fileSrc;
+    } else {
+      this.videoSrc = URL.createObjectURL(this.file.file);
+      this.sanitizedVideoSrc = this.sanitizer.bypassSecurityTrustUrl(this.videoSrc);
+    }
+
   }
 
   ngOnDestroy() {

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -5,7 +5,7 @@ Default
 	(change)="onFilesAdded($event)">
 	<ngx-dropzone-label>Drop it, baby!</ngx-dropzone-label>
 	<ngx-dropzone-preview *ngFor="let f of files" [removable]="true" (removed)="onRemove(f)">
-		<ngx-dropzone-label>{{ f.name }} ({{ f.type }})</ngx-dropzone-label>
+		<ngx-dropzone-label class="dropzone-label">{{ f.file.name }} ({{ f.file.type }})</ngx-dropzone-label>
 	</ngx-dropzone-preview>
 </ngx-dropzone>
 
@@ -14,14 +14,14 @@ Default
 <ngx-dropzone (change)="onFilesAdded($event)" [disabled]="true" [expandable]="true">
 	<ngx-dropzone-label>Drop it like it's hot!</ngx-dropzone-label>
 	<ngx-dropzone-preview *ngFor="let f of files" [removable]="true" (removed)="onRemove(f)">
-		<ngx-dropzone-label>{{ f.name }} ({{ f.type }})</ngx-dropzone-label>
+		<ngx-dropzone-label class="dropzone-label">{{ f.file.name  }} ({{ f.file.type }})</ngx-dropzone-label>
 	</ngx-dropzone-preview>
 </ngx-dropzone>
 
 <ngx-dropzone (change)="onFilesAdded($event)" [multiple]="false" [disableClick]="true">
 	<ngx-dropzone-label>Drop it like it's hott!</ngx-dropzone-label>
 	<ngx-dropzone-preview *ngFor="let f of files" [removable]="true" (removed)="onRemove(f)">
-		<ngx-dropzone-label>{{ f.name }} ({{ f.type }})</ngx-dropzone-label>
+		<ngx-dropzone-label class="dropzone-label">{{ f.file.name  }} ({{ f.file.type }})</ngx-dropzone-label>
 	</ngx-dropzone-preview>
 </ngx-dropzone>
 
@@ -31,10 +31,9 @@ Default
 			<h2>My custom dropzone I</h2>
 		</div>
 	</ngx-dropzone-label>
-	<p>P-Element</p>
 	<ngx-dropzone-image-preview ngProjectAs="ngx-dropzone-preview" *ngFor="let f of files" [file]="f" [removable]="true"
 		(removed)="onRemove(f)">
-		<ngx-dropzone-label>{{ f.name }} ({{ f.type }})</ngx-dropzone-label>
+		<ngx-dropzone-label class="dropzone-label">{{ f.file.name  }} ({{ f.file.type }})</ngx-dropzone-label>
 	</ngx-dropzone-image-preview>
 </div>
 
@@ -46,7 +45,7 @@ Default
 	</ngx-dropzone-label>
 	<ngx-dropzone-video-preview ngProjectAs="ngx-dropzone-preview" *ngFor="let f of files" [file]="f" [removable]="true"
 		(removed)="onRemove(f)">
-		<ngx-dropzone-label>{{ f.name }} ({{ f.type }})</ngx-dropzone-label>
+		<ngx-dropzone-label class="dropzone-label">{{ f.file.name  }} ({{ f.file.type }})</ngx-dropzone-label>
 	</ngx-dropzone-video-preview>
 </div>
 
@@ -57,6 +56,6 @@ Default
 		</div>
 	</ngx-dropzone-label>
 	<ngx-dropzone-preview *ngFor="let f of files" [file]="f" [removable]="true" (removed)="onRemove(f)">
-		<ngx-dropzone-label>{{ f.name }} ({{ f.type }})</ngx-dropzone-label>
+		<ngx-dropzone-label class="dropzone-label">{{ f.file.name  }} ({{ f.file.type }})</ngx-dropzone-label>
 	</ngx-dropzone-preview>
 </div>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -15,3 +15,11 @@ ngx-dropzone {
 		border: 5px solid rgb(235, 79, 79);
 	}
 }
+.dropzone-label{
+  bottom: 0;
+  background: rgba(255,255,255,0.4);
+    color: #333;
+  padding: 0 ;
+  border-radius: 5px;
+  font-size: 10px;
+}

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,25 +1,58 @@
-import { Component } from '@angular/core';
+import { AfterViewInit, Component } from '@angular/core';
+import { DropZoneFileModel } from 'projects/ngx-dropzone/src/lib/_data';
 
 @Component({
-	selector: 'app-root',
-	templateUrl: './app.component.html',
-	styleUrls: ['./app.component.scss']
+  selector: 'app-root',
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.scss']
 })
-export class AppComponent {
+export class AppComponent implements AfterViewInit {
 
-	files: File[] = [];
+  files: DropZoneFileModel[] = [];
 
-	onFilesAdded(event) {
-		console.log(event);
-		this.files.push(...event.addedFiles);
-	}
 
-	onFilesRejected(event) {
-		console.log(event);
-	}
+  ngAfterViewInit() {
 
-	onRemove(event) {
-		console.log(event);
-		this.files.splice(this.files.indexOf(event), 1);
-	}
+    const url = 'https://fakeimg.pl/440x230/282828/32eddd/?retina=1&text=ngx-dropzone-mock-img';
+
+    const nameWithType = url.split('/')[url.split('/').length - 1];
+    const name = nameWithType.split('.')[0];
+    const type = nameWithType.split('.')[1] ? nameWithType.split('.')[1].toLowerCase() : 'png';
+
+    var mockFile: File = {
+      name: name,
+      type: "image/" + type,
+      size: 1024,
+      arrayBuffer: null,
+      lastModified: null,
+      slice: null,
+      stream: null,
+      text: null,
+    };
+
+    this.files.push({
+      isMock: true,
+      file: mockFile,
+      fileSrc: url
+    })
+  }
+
+  onFilesAdded(event: any) {
+    console.log(event);
+    event.addedFiles.forEach((element: any) => {
+      this.files.push({
+        file: element,
+        isMock: false
+      })
+    });
+  }
+
+  onFilesRejected(event: any) {
+    console.log(event);
+  }
+
+  onRemove(event: DropZoneFileModel) {
+    console.log(event);
+    this.files.splice(this.files.indexOf(event), 1);
+  }
 }


### PR DESCRIPTION
some times we need to preload files
like when we going to add an entity then let's say we want to edit the entity and its images or files
then in the edit component, we need to first preload the files to the drop-zone

before the changes that I made we needed to download the file and create a real file from it 
which was a very bad idea
now its good to go


I changed the readme file hope you understand what I did :)