### PR TITLE
Use defaultImg if Type is not supported + SVG Support

### DIFF
--- a/projects/ngx-dropzone/src/lib/ngx-dropzone-preview/ngx-dropzone-image-preview/ngx-dropzone-image-preview.component.ts
+++ b/projects/ngx-dropzone/src/lib/ngx-dropzone-preview/ngx-dropzone-image-preview/ngx-dropzone-image-preview.component.ts
@@ -30,7 +30,7 @@ export class NgxDropzoneImagePreviewComponent extends NgxDropzonePreviewComponen
   @Input()
   set file(value: File) {
     this._file = value;
-    this.renderImage();
+    this.checkFileType();
   }
   get file(): File { return this._file; }
 
@@ -39,12 +39,23 @@ export class NgxDropzoneImagePreviewComponent extends NgxDropzonePreviewComponen
   imageSrc: any = this.sanitizer.bypassSecurityTrustUrl(this.defaultImgLoading);
 
   ngOnInit() {
-    this.renderImage();
+    this.checkFileType();
   }
 
+  private checkFileType() {
+    const supportedTypes = [
+      "image/png",
+      "image/jpeg",
+      "image/gif",
+      "image/tiff",
+      "image/bmp",
+      "image/svg+xml"
+    ]
+    if (supportedTypes.findIndex(x => x === this.file.type) > -1 ) { this.renderImage(); }
+  }
   private renderImage() {
     this.readFile()
-      .then(img => setTimeout(() => this.imageSrc = img))
+      .then(img => setTimeout(() => {this.imageSrc = this.sanitizer.bypassSecurityTrustUrl(img as any);}))
       .catch(err => console.error(err));
   }
 }


### PR DESCRIPTION
Checking File Type and use default Img if type is not supported by readFile(). Maybe more working, but haven't tested all to be sure that .startsWith("image/") works.
Added Support for "image/svg+xml" (sanitizing), at least Chrome raises error if not sanitized.