### PR TITLE
implemented ability to drop directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ This component has the following Input properties:
 * `[expandable]`: Allow the dropzone container to expand vertically as the number of previewed files increases. Defaults to `false` which means that it will allow for horizontal scrolling.
 * `[disableClick]`: Prevent the file selector from opening when clicking the dropzone.
 * `[id], [aria-label], [aria-labelledby]`, `[aria-describedby]`: Forward the accessibility properties to the file input element.
+* `[processDirectoryDrop]`: Enable extracting files from dropped directories. Defaults to `false`.
 
 It has the following Output event:
 

--- a/projects/ngx-dropzone/src/lib/ngx-dropzone/ngx-dropzone.component.ts
+++ b/projects/ngx-dropzone/src/lib/ngx-dropzone/ngx-dropzone.component.ts
@@ -1,5 +1,5 @@
-import { Component, OnInit, EventEmitter, Output, Input, ViewChild, ContentChildren, QueryList, HostBinding, HostListener, Self, ElementRef } from '@angular/core';
-import {NgxDropzoneService, FileSelectResult, RejectedFile} from '../ngx-dropzone.service';
+import { Component, EventEmitter, Output, Input, ViewChild, ContentChildren, QueryList, HostBinding, HostListener, Self, ElementRef } from '@angular/core';
+import {NgxDropzoneService, RejectedFile} from '../ngx-dropzone.service';
 import { coerceBooleanProperty, coerceNumberProperty } from '../helpers';
 import { NgxDropzonePreviewComponent } from '../ngx-dropzone-preview/ngx-dropzone-preview.component';
 
@@ -19,7 +19,7 @@ export class NgxDropzoneComponent {
 
   constructor(
     @Self() private service: NgxDropzoneService
-  ) { }
+  ) {}
 
   /** A list of the content-projected preview children. */
   @ContentChildren(NgxDropzonePreviewComponent, { descendants: true })
@@ -95,6 +95,16 @@ export class NgxDropzoneComponent {
   }
   private _disableClick = false;
 
+  /** Allow dropping directories. */
+  @Input()
+  get processDirectoryDrop(): boolean {
+    return this._processDirectoryDrop;
+  }
+  set processDirectoryDrop(value: boolean) {
+    this._processDirectoryDrop = coerceBooleanProperty(value);
+  }
+  private _processDirectoryDrop = false;
+
   /** Expose the id, aria-label, aria-labelledby and aria-describedby of the native file input for proper accessibility. */
   @Input() id: string;
   @Input('aria-label') ariaLabel: string;
@@ -135,7 +145,94 @@ export class NgxDropzoneComponent {
 
     this.preventDefault(event);
     this._isHovered = false;
-    this.handleFileDrop(event.dataTransfer.files);
+
+    // if processDirectoryDrop is not enabled or webkitGetAsEntry is not supported we handle the drop as usual
+    if (!this.processDirectoryDrop || !DataTransferItem.prototype.webkitGetAsEntry) {
+      this.handleFileDrop(event.dataTransfer.files);
+
+    // if processDirectoryDrop is enabled and webkitGetAsEntry is supported we can extract files from a dropped directory
+    } else {
+      const droppedItems: DataTransferItem[] = event.dataTransfer.items;
+
+      if (droppedItems.length > 0) {
+        const droppedFiles: File[] = [];
+        const droppedDirectories = [];
+
+        // seperate dropped files from dropped directories for easier handling
+        for (let i = 0; i < droppedItems.length; i++) {
+          const entry = droppedItems[i].webkitGetAsEntry();
+          if (entry.isFile) {
+            droppedFiles.push(event.dataTransfer.files[i]);
+          } else if (entry.isDirectory) {
+            droppedDirectories.push(entry);
+          }
+        }
+
+        // create a DataTransfer
+        const droppedFilesList = new DataTransfer();
+        droppedFiles.forEach((droppedFile) => {
+          droppedFilesList.items.add(droppedFile);
+        });
+
+        // if no directory is dropped we are done and can call handleFileDrop
+        if (!droppedDirectories.length && droppedFilesList.items.length) {
+          this.handleFileDrop(droppedFilesList.files);
+        }
+
+        // if directories are dropped we extract the files from these directories one-by-one and add it to droppedFilesList
+        if (droppedDirectories.length) {
+          const extractFilesFromDirectoryCalls = [];
+
+          for (const droppedDirectory of droppedDirectories) {
+            extractFilesFromDirectoryCalls.push(this.extractFilesFromDirectory(droppedDirectory));
+          }
+
+          // wait for all directories to be proccessed to add the extracted files afterwards
+          Promise.all(extractFilesFromDirectoryCalls).then((allExtractedFiles: any[]) => {
+            allExtractedFiles.reduce((a, b) => [...a, ...b]).forEach((extractedFile: File) => {
+              droppedFilesList.items.add(extractedFile);
+            });
+
+            this.handleFileDrop(droppedFilesList.files);
+          });
+        }
+      }
+    }
+  }
+
+  private extractFilesFromDirectory(directory) {
+    async function getFileFromFileEntry(fileEntry) {
+      try {
+        return await new Promise((resolve, reject) => fileEntry.file(resolve, reject));
+      } catch (err) {
+        console.log('Error converting a fileEntry to a File: ', err);
+      }
+    }
+
+    return new Promise((resolve, reject) => {
+      const files: File[] = [];
+
+      const dirReader = directory.createReader();
+
+      // we need this to be a recursion because of this issue: https://bugs.chromium.org/p/chromium/issues/detail?id=514087
+      const readEntries = () => {
+        dirReader.readEntries(async(dirItems) => {
+          if (!dirItems.length) {
+            resolve(files);
+          } else {
+            const fileEntries = dirItems.filter((dirItem) => dirItem.isFile);
+
+            for (const fileEntry of fileEntries) {
+              const file: any = await getFileFromFileEntry(fileEntry);
+              files.push(file);
+            }
+
+            readEntries();
+          }
+        });
+      };
+      readEntries();
+    });
   }
 
   showFileSelector() {

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -11,6 +11,13 @@ Default
 
 <button (click)="drop.showFileSelector()">Open</button>
 
+<ngx-dropzone (change)="onFilesAdded($event)" [processDirectoryDrop]="true">
+	<ngx-dropzone-label>Drop your directories in here, to see the magic happen!</ngx-dropzone-label>
+	<ngx-dropzone-preview *ngFor="let f of files" [removable]="true" (removed)="onRemove(f)">
+		<ngx-dropzone-label>{{ f.name }} ({{ f.type }})</ngx-dropzone-label>
+	</ngx-dropzone-preview>
+</ngx-dropzone>
+
 <ngx-dropzone (change)="onFilesAdded($event)" [disabled]="true" [expandable]="true">
 	<ngx-dropzone-label>Drop it like it's hot!</ngx-dropzone-label>
 	<ngx-dropzone-preview *ngFor="let f of files" [removable]="true" (removed)="onRemove(f)">


### PR DESCRIPTION
Hey Peter!

I'm working at a company where we are heavily using your wonderful extension.
Many customers reached out to us and asked whether we could implement the ability to drop directories additionally to files.
Note that i added a new configuration property `processDirectoryDrop` to enable / disable this new feature which is `false` as default to not mess with any existing implementations.
Additionally a new example is provided in app.component as well.
I would be more than happy if you could accept this request as i think this would benefit a lot of people :) 

Kind regards,
IlChillberto